### PR TITLE
Suggestion: Update the github repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,9 @@ Currently, webhooks are not available for OAuth 2.0 apps, for more information: 
 
 ## Contributing
 We are always grateful for any kind of contribution including but not limited to bug reports, code enhancements, bug fixes, and even functionality suggestions.
-#### You can report any bug you find or suggest new functionality with a new [issue](https://github.com/ingmferrer/jira-cloud-python/issues).
+#### You can report any bug you find or suggest new functionality with a new [issue](https://github.com/GearPlug/jira-cloud-python/issues).
 #### If you want to add yourself some functionality to the wrapper:
-1. Fork it ( https://github.com/ingmferrer/jira-cloud-python )
+1. Fork it ( https://github.com/GearPlug/jira-cloud-python )
 2. Create your feature branch (git checkout -b my-new-feature)
 3. Commit your changes (git commit -am 'Adds my new feature')
 4. Push to the branch (git push origin my-new-feature)


### PR DESCRIPTION
The pypi page uses this README which refers back to a missing repository on Github. https://pypi.org/project/jira-cloud-python/1.0.1/